### PR TITLE
[Docs] Add clickable links for security tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,10 +107,10 @@
   _GoReleaser cuts signed, versioned artifacts the moment you push a tag—shipping new versions becomes a 10-second ritual._
 
 - **🛡️ Security & Supply-chain Guardrails**  
-  _Dependabot, Nancy, govulncheck, CodeQL, OpenSSF Scorecard, and gitleaks give early warnings before bad things reach production._
+  _[Dependabot](https://dependabot.com), [Nancy](https://github.com/sonatype-nexus-community/nancy), [govulncheck](https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck), [CodeQL](https://docs.github.com/en/github/finding-security-vulnerabilities-and-errors-in-your-code/about-code-scanning), [OpenSSF Scorecard](https://openssf.org), and [gitleaks](https://github.com/gitleaks/gitleaks) give early warnings before bad things reach production._
 
 - **🎨 Style & Quality Enforcement**  
-  _gofumpt + golangci-lint keeps the codebase clean and idiomatic—no bikeshedding required._
+  _[gofumpt](https://github.com/mvdan/gofumpt) + [golangci-lint](https://github.com/golangci/golangci-lint) keeps the codebase clean and idiomatic—no bikeshedding required._
 
 - **🌍 Community-Ready Meta**  
   _Issue/PR templates, CODEOWNERS, label sync, and a welcome bot show contributors exactly how to get involved._


### PR DESCRIPTION
#### What Changed
- linked Dependabot, Nancy, govulncheck, CodeQL, OpenSSF Scorecard, gitleaks, gofumpt, and golangci-lint in the README

#### Why It Was Necessary
- readers can easily jump to each security or linting resource

#### Testing Performed
- `go fmt ./...`
- `goimports -w .`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`

#### Impact / Risk
- documentation only; no functional impact

------
https://chatgpt.com/codex/tasks/task_e_685f22f78128832191bcf62b013b8321