### PR TITLE
[CI] Pin GitHub Script version

### DIFF
--- a/.github/workflows/auto-merge-on-approval.yml
+++ b/.github/workflows/auto-merge-on-approval.yml
@@ -49,7 +49,7 @@ jobs:
 
         steps:
             - name: Attempt auto‑merge
-              uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+              uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
               with:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   script: |


### PR DESCRIPTION
### What Changed
- updated comment in auto-merge workflow to reflect `actions/github-script` version v7.0.1

### Why It Was Necessary
- clarifies the exact minor version pinned for the GitHub Script action

### Testing Performed
- `go fmt ./...`
- `goimports -w .`
- `golangci-lint run`
- `go vet ./...`
- `go test ./...`

### Impact / Risk
- low risk; workflow functionality remains the same

------
https://chatgpt.com/codex/tasks/task_e_68629301d1d083218d307f9951ec2f54