### PR TITLE
[CI] Pin CodeQL workflow to v3.29.2

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -51,7 +51,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@39edc492dbe16b1465b0cafca41432d857bdb31a # v3
+        uses: github/codeql-action/init@181d5eefc20863364f96762470ba6f862bdef56b # v3.29.2
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -62,7 +62,7 @@ jobs:
       # Autobuild attempts to build any compiled languages (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@39edc492dbe16b1465b0cafca41432d857bdb31a # v3
+        uses: github/codeql-action/autobuild@181d5eefc20863364f96762470ba6f862bdef56b # v3.29.2
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 https://git.io/JvXDl
@@ -76,4 +76,4 @@ jobs:
       #   make release
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@39edc492dbe16b1465b0cafca41432d857bdb31a # v3
+        uses: github/codeql-action/analyze@181d5eefc20863364f96762470ba6f862bdef56b # v3.29.2


### PR DESCRIPTION
## What Changed
- pinned `github/codeql-action` steps in `codeql-analysis.yml` to commit `181d5eefc20863364f96762470ba6f862bdef56b`
- updated workflow comments to reflect version `v3.29.2`

## Why It Was Necessary
- ensures deterministic builds and aligns with the current CodeQL release

## Testing Performed
- `go test ./...`

## Impact / Risk
- no breaking changes; CI workflow remains the same with a patched CodeQL version.

------
https://chatgpt.com/codex/tasks/task_e_6862935fe16083219cc0b3602ec06851