### PR TITLE
[CI] Specify github-script minor version

### DIFF
--- a/.github/workflows/delete-merged-branches.yml
+++ b/.github/workflows/delete-merged-branches.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       # Step 1: Use github-script to run custom JS for branch deletion
       - name: Delete branch
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |


### PR DESCRIPTION
## What Changed
- updated pinned comment for `actions/github-script` to show full version `v7.0.1`

## Why It Was Necessary
- clarifies which release commit is pinned for the action

## Testing Performed
- `go test ./...`

## Impact / Risk
- no functional changes; workflow behavior is unchanged

------
https://chatgpt.com/codex/tasks/task_e_686293842ab88321a83f0fe4609dcb2d