### PR TITLE
[CI] Update github-script pin to v7.0.1

### DIFF
--- a/.github/workflows/pull-request-management.yml
+++ b/.github/workflows/pull-request-management.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Add labels based on branch
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |


### PR DESCRIPTION
#### What Changed
- updated `pull-request-management.yml` to comment pinned version 7.0.1 for `actions/github-script`

#### Why It Was Necessary
- ensures the workflow documents the exact action release matching the pinned SHA

#### Testing Performed
- `go test ./...`

#### Impact / Risk
- no functional changes; minimal risk

------
https://chatgpt.com/codex/tasks/task_e_686293b6c1a48321896d6f66a997714a