### PR TITLE
[Docs] Add pre-commit configuration

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -626,6 +626,7 @@ CI automatically runs on every PR to verify:
 * Linting (`golangci-lint run`)
 * Tests (`go test ./...`)
 * Fuzz tests (if applicable) (`make run-fuzz-tests`)
+* Pre‑commit hooks (`pre-commit install && pre-commit run --files <files>`) keep local commits aligned with CI
 * This codebase uses GitHub Actions; test workflows reside in `.github/workflows/run-tests.yml`
 * Pin each external GitHub Action to a **full commit SHA** (e.g., `actions/checkout@2f3b4a2e0e471e13e2ea2bc2a350e888c9cf9b75`) as recommended by GitHub's [security hardening guidance](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-pinned-actions). Dependabot will track and update these pinned versions automatically.
 
@@ -725,6 +726,7 @@ All contributors are expected to append entries here when making meaningful chan
 
 | Date       | Author   | Summary of Changes                                                             |
 |------------|----------|--------------------------------------------------------------------------------|
+| 2025-06-30 | @mrz1836 | Added pre-commit hook guidelines and config reference |
 | 2025-06-27 | @mrz1836 | Adapted to fix this project go-template                                        |
 | 2025-06-26 | @mrz1836 | Documented citation and configuration files for contributors                   |
 > For minor edits (typos, formatting), this log update is optional. For all behavioral or structural changes, log entries are **required**.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -8,9 +8,14 @@ Thanks for taking the time to contribute! This project thrives on clear, well-te
 
 1. Fork the repo.
 2. Create a new branch.
-3. Commit *one feature per commit*.
-4. Write tests.
-5. Open a pull request with a clear list of changes.
+3. Install the pre-commit hooks:
+   ```bash
+   pip install pre-commit
+   pre-commit install
+   ```
+4. Commit *one feature per commit*.
+5. Write tests.
+6. Open a pull request with a clear list of changes.
 
 More info on [pull requests](http://help.github.com/pull-requests/).
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,27 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-added-large-files
+      - id: check-merge-conflict
+
+  - repo: https://github.com/dnephin/pre-commit-golang
+    rev: v1.3.0
+    hooks:
+      - id: gofmt
+      - id: goimports
+      - id: govet
+      - id: golangci-lint
+        args: ["--config=.golangci.json"]
+      - id: go-unit-tests
+        args: ["-v", "./..."]
+
+  - repo: local
+    hooks:
+      - id: go-mod-tidy
+        name: go-mod-tidy
+        entry: go mod tidy
+        language: system
+        pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -461,6 +461,17 @@ This command ensures all dependencies are brought up to date in a single step, i
 
 </details>
 
+## 🔄 Pre-commit Hooks
+
+Set up the optional [pre-commit](https://pre-commit.com) hooks to run the same formatting, linting, and tests defined in [AGENTS.md](.github/AGENTS.md) before every commit:
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+The hooks are configured in [.pre-commit-config.yaml](.pre-commit-config.yaml) and mirror the CI pipeline.
+
 <br/>
 
 ## 🧪 Examples & Tests


### PR DESCRIPTION
## What Changed
- add `.pre-commit-config.yaml` with hooks for formatting, linting and tests
- mention pre‑commit in `CONTRIBUTING.md` and `README.md`
- document pre‑commit usage in `AGENTS.md` change log

## Why It Was Necessary
- to help contributors run the same checks locally before pushing

## Testing Performed
- `go test ./...`
- `golangci-lint run`

## Impact / Risk
- Low: adds optional development tooling


------
https://chatgpt.com/codex/tasks/task_e_6862a2358df48321a5a08f5f81984c48