### PR TITLE
[CI] Tighten pre‑commit workflow security

### DIFF
--- a/.github/workflows/update-pre-commit-hooks.yml
+++ b/.github/workflows/update-pre-commit-hooks.yml
@@ -17,7 +17,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
   pull-requests: write
 
 concurrency:
@@ -27,6 +27,9 @@ concurrency:
 jobs:
   update-hooks:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       # Checkout code
       - name: Checkout code
@@ -40,7 +43,7 @@ jobs:
 
       # Install pre-commit
       - name: Install pre-commit
-        run: pip install pre-commit
+        run: pip install pre-commit==3.7.0
 
       # Run pre-commit autoupdate
       - name: Run pre-commit autoupdate


### PR DESCRIPTION
## What Changed
- reduced default token permissions to read-only
- escalated permissions for update job
- pinned `pre-commit` installation to version 3.7.0

## Why It Was Necessary
The OpenSSF scorecard flagged write-level `contents` permissions and an unpinned `pip` command in `update-pre-commit-hooks.yml`. Restricting the default token scope and pinning dependencies improves workflow security.

## Testing Performed
- `go vet ./...`
- `staticcheck ./...`
- `golangci-lint run`
- `go test ./...`

## Impact / Risk
- No breaking changes. Workflow will continue to update pre-commit hooks weekly with tighter permissions.

------
https://chatgpt.com/codex/tasks/task_e_68631dd87c848321ba42bffb34f35b39