### PR TITLE
[CI] Cache pip dependencies for update hooks

### DIFF
--- a/.github/workflows/update-pre-commit-hooks.yml
+++ b/.github/workflows/update-pre-commit-hooks.yml
@@ -41,6 +41,15 @@ jobs:
         with:
           python-version: '3.x'
 
+      # Cache pip dependencies
+      - name: Cache pip dependencies
+        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # v3.0.11
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
       # Install pre-commit
       - name: Install pre-commit
         run: pip install pre-commit==3.7.0


### PR DESCRIPTION
## What Changed
- cached pip dependencies in `update-pre-commit-hooks.yml`
- pinned `actions/cache` to `v3.0.11` commit SHA

## Why It Was Necessary
- caching speeds up the workflow and SHA pinning follows security best practices

## Testing Performed
- `go test ./...`
- attempted `pre-commit` which failed due to network restrictions

## Impact / Risk
- minimal; workflow improvement only

## Notifications
- @mrz1836

------
https://chatgpt.com/codex/tasks/task_e_686320e5bfe48321a3b34fbea4e3730f