### PR TITLE
[CI] Add workflow to update pip requirements

### DIFF
--- a/.github/scripts/update_pip_requirements.py
+++ b/.github/scripts/update_pip_requirements.py
@@ -1,0 +1,44 @@
+import subprocess
+import tempfile
+import re
+from pathlib import Path
+
+REQ_FILE = Path('.github/pip-requirements.txt')
+
+def get_latest_version(pkg: str) -> str:
+    result = subprocess.check_output(['pip', 'index', 'versions', pkg], text=True)
+    first = result.splitlines()[0]
+    m = re.search(r'\(([^\)]+)\)', first)
+    if not m:
+        raise RuntimeError(f'Cannot parse version for {pkg}')
+    return m.group(1)
+
+def get_hash(pkg: str, version: str) -> str:
+    with tempfile.TemporaryDirectory() as tmp:
+        subprocess.check_call(['pip', 'download', '--no-deps', f'{pkg}=={version}', '-d', tmp])
+        files = list(Path(tmp).iterdir())
+        if not files:
+            raise RuntimeError(f'No files downloaded for {pkg}=={version}')
+        file_path = files[0]
+        hash_result = subprocess.check_output(['sha256sum', file_path], text=True)
+        return hash_result.split()[0]
+
+def main() -> None:
+    content = REQ_FILE.read_text().splitlines()
+    pkgs = []
+    for line in content:
+        if not line or line.startswith('#'):
+            continue
+        if '==' in line:
+            pkg = line.split('==')[0].strip().replace('\\', '')
+            pkgs.append(pkg)
+    new_lines = []
+    for pkg in pkgs:
+        version = get_latest_version(pkg)
+        sha = get_hash(pkg, version)
+        new_lines.append(f'{pkg}=={version} \\')
+        new_lines.append(f'    --hash=sha256:{sha}')
+    REQ_FILE.write_text('\n'.join(new_lines) + '\n')
+
+if __name__ == '__main__':
+    main()

--- a/.github/workflows/update-pip-requirements.yml
+++ b/.github/workflows/update-pip-requirements.yml
@@ -1,0 +1,60 @@
+# ------------------------------------------------------------------------------
+#  Update pip Requirements Workflow
+#
+#  Purpose: Automatically update Python dependencies listed in
+#           `.github/pip-requirements.txt` and open a pull request.
+#
+#  Triggers: Runs every Monday at 08:20 UTC and can be triggered manually.
+#
+#  Maintainer: @mrz1836
+# ------------------------------------------------------------------------------
+
+name: update-pip-requirements
+
+on:
+  schedule:
+    # ┌─ min ┬─ hour ┬─ dom ┬─ mon ┬─ dow ┐
+    - cron: '20 8 * * 1'   # Every Monday at 08:20 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  update-requirements:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: '3.x'
+
+      - name: Cache pip dependencies
+        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # v3.0.11
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('.github/pip-requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Update requirements file
+        run: python .github/scripts/update_pip_requirements.py
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
+        with:
+          commit-message: 'chore: update pip requirements'
+          title: 'chore: update pip requirements'
+          body: 'This PR updates the Python dependencies in `.github/pip-requirements.txt`. '
+          branch: 'chore/update-pip-requirements'


### PR DESCRIPTION
## Summary
- add a workflow that updates `.github/pip-requirements.txt`
- include helper script to fetch latest versions and sha256 hashes

## Testing
- `go vet ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68632d033ca083218f4ca0be5ac9e140