### PR TITLE
[CI] Pin pre-commit version

### DIFF
--- a/.github/workflows/update-pre-commit-hooks.yml
+++ b/.github/workflows/update-pre-commit-hooks.yml
@@ -92,7 +92,8 @@ jobs:
             pip install --require-hashes -r .github/pip-requirements.txt
           else
             echo "No requirements file found, installing pre-commit directly..."
-            pip install pre-commit
+            pip install --no-cache-dir pre-commit==4.2.0 \
+              --hash=sha256:a009ca7205f1eb497d10b845e52c838a98b6cdd2102a6c8e4540e94ee75c58bd
           fi
 
           # Verify installation


### PR DESCRIPTION
## What Changed
- Pin `pre-commit` installation in workflow to version 4.2.0 with SHA hash

## Why It Was Necessary
- Security scanners flagged the unpinned `pip install` command as a risk

## Testing Performed
- `go fmt ./...`
- `go test ./...`
- `make run-fuzz-tests`
- `golangci-lint run` *(failed: unknown linters)*

## Impact / Risk
- Low risk; workflow uses a fixed `pre-commit` version ensuring deterministic installs

------
https://chatgpt.com/codex/tasks/task_e_686d7d342a548321ab540503724cbfc3