### PR TITLE
[CI] Pin pip install commands

### DIFF
--- a/.github/workflows/update-pip-requirements.yml
+++ b/.github/workflows/update-pip-requirements.yml
@@ -101,13 +101,13 @@ jobs:
             python .github/scripts/update_pip_requirements.py
           else
             echo "No custom script found, using default pip-tools approach..."
-            pip install pip-tools
+            pip install pip-tools==7.4.1 --hash=sha256:4c690e5fbae2f21e87843e89c26191f0d9454f362d8acdbd695716493ec8b3a9
             # If requirements.in exists, compile it; otherwise work with existing .txt
             if [ -f ".github/pip-requirements.in" ]; then
               pip-compile --upgrade .github/pip-requirements.in --output-file "${{ env.REQUIREMENTS_FILE }}"
             else
               echo "No .in file found, attempting to upgrade existing requirements..."
-              pip install --upgrade -r "${{ env.REQUIREMENTS_FILE }}" --dry-run || echo "No packages to upgrade"
+              pip install --upgrade --require-hashes -r "${{ env.REQUIREMENTS_FILE }}" --dry-run || echo "No packages to upgrade"
             fi
           fi
 


### PR DESCRIPTION
## What Changed
- pinned `pip install` commands in `update-pip-requirements.yml`

## Why It Was Necessary
- resolves security warning about unpinned pip commands

## Testing Performed
- `go vet ./...`
- `go test ./...`
- `gitleaks detect --source . --log-opts="--all" --verbose`
- `golangci-lint run` *(failed: unknown linters)*
- `govulncheck ./...` *(failed: Forbidden)*

## Impact / Risk
- CI workflow now installs dependencies in a reproducible way


------
https://chatgpt.com/codex/tasks/task_e_686d7d5a3e108321a420a8ff900e99f5