### PR TITLE
[CI] Fix pip install hash for pre-commit

### DIFF
--- a/.github/workflows/update-pre-commit-hooks.yml
+++ b/.github/workflows/update-pre-commit-hooks.yml
@@ -87,14 +87,13 @@ jobs:
       # ————————————————————————————————————————————————————————————————
       - name: Install pre-commit
         run: |
-          if [ -f ".github/pip-requirements.txt" ]; then
-            echo "Installing pre-commit from requirements file..."
-            pip install --require-hashes -r .github/pip-requirements.txt
-          else
-            echo "No requirements file found, installing pre-commit directly..."
-            pip install --no-cache-dir pre-commit==4.2.0 \
-              --hash=sha256:a009ca7205f1eb497d10b845e52c838a98b6cdd2102a6c8e4540e94ee75c58bd
+          if [ ! -f ".github/pip-requirements.txt" ]; then
+            echo "❌ Requirements file .github/pip-requirements.txt not found"
+            exit 1
           fi
+
+          echo "Installing pre-commit from requirements file..."
+          pip install --require-hashes -r .github/pip-requirements.txt
 
           # Verify installation
           pre-commit --version


### PR DESCRIPTION
## What Changed
- enforce using `.github/pip-requirements.txt` when installing `pre-commit`
- fail workflow if the requirements file is missing

## Why It Was Necessary
The Scorecard check flagged the workflow for installing `pre-commit` without fully hashed dependencies. Installing directly allowed unpinned transient packages. Using the requirements file resolves this security warning.

## Testing Performed
- `go vet ./...`
- `go test ./...`
- `golangci-lint run` *(failed: unknown linters)*
- `pre-commit run --all-files` *(failed: network restrictions)*

## Impact / Risk
- Low risk: CI workflow change only
- Ensures deterministic Python dependencies and removes security warning.

------
https://chatgpt.com/codex/tasks/task_e_686d7f7393d8832199bd390465470779