### PR TITLE
[Sync] Update project files from source repository (9d58dbe)

### DIFF
--- a/.github/actions/validate-test-results/action.yml
+++ b/.github/actions/validate-test-results/action.yml
@@ -221,6 +221,20 @@ runs:
         # Strip backticks AND control chars (except tab/newline) from artifact-derived text:
         # prevents code-span/fenced-block breakout and control-character (ANSI/NUL) spoofing.
         strip_bt() { printf '%s' "$1" | LC_ALL=C tr -d '\000-\010\013-\037\140\177'; }
+        # esc_html: strip_bt PLUS escape the HTML metacharacters &, <, > (& first, to avoid
+        # double-encoding). Use ONLY for artifact-derived values written into the summary's raw
+        # HTML (<summary>/<code>) or into markdown text where GitHub interprets inline HTML —
+        # otherwise a crafted value (e.g. a subtest name) could close a tag early and spoof the
+        # rendered structure. Do NOT use inside markdown code spans/fences, where entities are
+        # rendered literally (there strip_bt alone already prevents breakout).
+        esc_html() {
+          local s
+          s=$(strip_bt "$1")
+          s=${s//&/&amp;}
+          s=${s//</&lt;}
+          s=${s//>/&gt;}
+          printf '%s' "$s"
+        }
 
         echo "## 🔍 Test Validation Summary" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
@@ -279,7 +293,7 @@ runs:
               ARTIFACT_DIR=$(basename "$(dirname "$jsonl_file")")
             fi
 
-            TEST_LABEL=$(strip_bt "$(parse_test_label "$ARTIFACT_DIR" "$JSONL_NAME")")
+            TEST_LABEL=$(esc_html "$(parse_test_label "$ARTIFACT_DIR" "$JSONL_NAME")")
 
             SUMMARY=$(grep '"type":"summary"' "$jsonl_file" 2>/dev/null | head -1 || echo "")
 
@@ -315,11 +329,14 @@ runs:
                 break 2
               fi
 
-              # Strip backticks from artifact-derived text so it cannot break out of the
-              # markdown code spans / fenced blocks it is written into below.
-              TEST=$(strip_bt "$(echo "$line" | jq -r '.failure.test // "unknown"')")
-              PKG=$(strip_bt "$(echo "$line" | jq -r '.failure.package // "unknown"' | sed 's|.*/||')")
-              FAIL_TYPE=$(strip_bt "$(echo "$line" | jq -r '.failure.type // "test"')")
+              # TEST/PKG/FAIL_TYPE are embedded directly in the raw HTML of the <summary>
+              # line below (<code>$TEST</code> ($PKG) - $FAIL_TYPE), so they are HTML-escaped
+              # to keep a crafted value from closing a tag early and spoofing the structure.
+              # ERROR_MSG/OUTPUT/STACK go inside markdown code spans/fences, where HTML is not
+              # interpreted, so backtick+control stripping (strip_bt) is enough there.
+              TEST=$(esc_html "$(echo "$line" | jq -r '.failure.test // "unknown"')")
+              PKG=$(esc_html "$(echo "$line" | jq -r '.failure.package // "unknown"' | sed 's|.*/||')")
+              FAIL_TYPE=$(esc_html "$(echo "$line" | jq -r '.failure.type // "test"')")
               ERROR_MSG=$(strip_bt "$(echo "$line" | jq -r '.failure.error // ""')")
               OUTPUT=$(strip_bt "$(echo "$line" | jq -r '.failure.output // ""')")
               STACK=$(strip_bt "$(echo "$line" | jq -r '.failure.stack // ""')")

--- a/.github/workflows/fortress.yml
+++ b/.github/workflows/fortress.yml
@@ -1,7 +1,7 @@
 # ------------------------------------------------------------------------------------
 #  🏰 GoFortress - Enterprise-grade CI/CD fortress for Go applications
 #
-#  Version: 1.8.1 | Released: 2026-05-29
+#  Version: 1.9.0 | Released: 2026-08-13
 #
 #  Built Strong. Tested Harder.
 #


### PR DESCRIPTION
## What Changed

* Added new `esc_html()` bash function in `.github/actions/validate-test-results/action.yml` that escapes HTML metacharacters (`&`, `<`, `>`) in addition to stripping backticks and control characters
* Updated `TEST_LABEL`, `TEST`, `PKG`, and `FAIL_TYPE` variables to use `esc_html()` instead of `strip_bt()` for sanitizing artifact-derived values that are embedded in raw HTML tags
* Added inline documentation explaining that `esc_html()` should be used for values written into summary's raw HTML (`<summary>/<code>` tags), while `strip_bt()` alone is sufficient for markdown code spans/fences
* Updated fortress.yml workflow version from `1.8.1` (released 2026-05-29) to `1.9.0` (released 2026-08-13)

## Why It Was Necessary

* Prevents HTML injection vulnerabilities where crafted artifact values (e.g., malicious subtest names) could close tags early and spoof the rendered structure in GitHub step summaries
* Provides defense-in-depth by properly escaping values that are embedded directly in raw HTML context, while maintaining appropriate sanitization for markdown contexts
* Documents the security boundary between HTML-interpreted contexts and markdown code contexts to prevent future security regressions

## Testing Performed

* Verified that the new `esc_html()` function correctly escapes HTML metacharacters in the order that prevents double-encoding (ampersand first)
* Validated that artifact-derived values in `<code>` tags and `<summary>` elements are now properly escaped
* Confirmed that values in markdown code spans/fences continue to use `strip_bt()` only, as HTML entities would be rendered literally in those contexts

## Impact / Risk

* **Security Improvement**: Fixes potential HTML injection vulnerability in GitHub Actions step summaries
* **Breaking Change**: None - output changes are purely cosmetic (HTML entities in rendered summaries)
* **Risk**: Low - changes are defensive sanitization improvements with no functional impact on test result processing

<!-- go-broadcast-metadata
group:
  id: mrz-sdks
  name: mrz-sdks
diff_info:
  staged_repo_available: true
  changed_files_count: 2
  files_with_original_content: 2
  files_without_original_content: 0
sync_metadata:
  source_repo: mrz1836/go-broadcast
  source_commit: 9d58dbe7c38b1688a0d14b919069d32354f8cfaf
  target_repo: mrz1836/go-template
  sync_commit: dc12d41b4b49345e825cebb9895718ca754e005e
  sync_time: 2026-08-14T18:49:08-04:00
ai_generated:
  commit_message: true
  pr_body: true
directories:
  - src: .github/ISSUE_TEMPLATE
    dest: .github/ISSUE_TEMPLATE
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 0
    files_examined: 3
    files_excluded: 0
    processing_time_ms: 265
  - src: .github/actions
    dest: .github/actions
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 1
    files_examined: 19
    files_excluded: 0
    processing_time_ms: 1067
  - src: .github/docs
    dest: .github/docs
    excluded: ["workflows-private.md"]
    files_synced: 0
    files_examined: 2
    files_excluded: 1
    processing_time_ms: 670
  - src: .github/env
    dest: .github/env
    excluded: ["20-guardian.env", "90-project.env", "99-local.env"]
    files_synced: 0
    files_examined: 9
    files_excluded: 2
    processing_time_ms: 791
  - src: .github/scripts
    dest: .github/scripts
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 0
    files_examined: 1
    files_excluded: 0
    processing_time_ms: 450
  - src: .github/tech-conventions
    dest: .github/tech-conventions
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 0
    files_examined: 14
    files_excluded: 0
    processing_time_ms: 1208
  - src: .github/workflows
    dest: .github/workflows
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 1
    files_examined: 20
    files_excluded: 0
    processing_time_ms: 1622
  - src: .vscode
    dest: .vscode
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 0
    files_examined: 4
    files_excluded: 0
    processing_time_ms: 607
performance:
  total_files: 103
-->
